### PR TITLE
Issue #56: require at least one device for 'fritzctl toggle'

### DIFF
--- a/cmd/toggle.go
+++ b/cmd/toggle.go
@@ -17,6 +17,7 @@ func init() {
 }
 
 func toggle(cmd *cobra.Command, args []string) error {
+	assertStringSliceHasAtLeast(args, 1, "insufficient input: device name(s) expected.\n\n", cmd.UsageString())
 	c := homeAutoClient()
 	err := c.Toggle(args...)
 	assertNoError(err, "error toggling device(s):", err)


### PR DESCRIPTION
Closes #56 