### PR TITLE
add helper method to determine if device has a temperature sensor

### DIFF
--- a/fritz/device.go
+++ b/fritz/device.go
@@ -29,3 +29,8 @@ func (d *Device) IsSwitch() bool {
 func (d *Device) IsThermostat() bool {
 	return bitMasked{Functionbitmask: d.Functionbitmask}.hasMask(64)
 }
+
+// Returns is the device has a temperature sensor
+func (d *Device) HasTemperatureSensor() bool {
+	return bitMasked{Functionbitmask: d.Functionbitmask}.hasMask(256)
+}


### PR DESCRIPTION
This PR adds a helper method to the device struct to identify if a device has the temperature sensor included. In general this PR also raises the question how to name the functions. From my perspective we should use the structure `has capability` instead of is `is`. AVM is mixing devices that share multiple features. Once we agree on a structure, we should harmonize the approach.

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>