### PR TITLE
Issue #146: Relative change of temperatures

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -28,6 +28,8 @@ func TestCommands(t *testing.T) {
 		{cmd: temperatureCmd, args: []string{"19.5", "HKR_1"}, srv: mock.New().UnstartedServer()},
 		{cmd: temperatureCmd, args: []string{"comf", "HKR_1"}, srv: mock.New().UnstartedServer()},
 		{cmd: temperatureCmd, args: []string{"sav", "HKR_1"}, srv: mock.New().UnstartedServer()},
+		{cmd: temperatureCmd, args: []string{"+", "1.5", "HKR_3"}, srv: mock.New().UnstartedServer()},
+		{cmd: temperatureCmd, args: []string{"-", "2", "HKR_3"}, srv: mock.New().UnstartedServer()},
 		{cmd: switchOnCmd, args: []string{"SWITCH_1"}, srv: mock.New().UnstartedServer()},
 		{cmd: switchOffCmd, args: []string{"SWITCH_2"}, srv: mock.New().UnstartedServer()},
 		{cmd: sessionIDCmd, srv: mock.New().UnstartedServer()},


### PR DESCRIPTION
Command line syntax:
  fritzctl temperature + 1 XYZ
  fritzctl temperature - 2 XYZ

Changes happen relative to the current goal temperature.
Notice the spaces between the sign and the delta!
Had to do this because the 'minus' can be confused with flags.

Closes #146 