### PR TITLE
Release to GitHub within gitlab runner job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,11 +36,12 @@ cq_job:
 deploy_job:
   only:
     - web
+    - tags
   stage: deploy
   script:
     - cd $GOPATH/src/github.com/bpicode/fritzctl
     - echo "$DEB_SIGNING_KEY_PRIVATE" | gpg --import
-    - make clean sysinfo dist_all pkg_all sign_deb publish_all
+    - make clean sysinfo dist_all pkg_all sign_deb publish_all release_github
     - gpg --batch --delete-secret-and-public-keys --yes 0A56A1CE2DFCECA404A5C884E4598EE3D0E416CE
     - cp -r $GOPATH/src/github.com/bpicode/fritzctl/build $CI_PROJECT_DIR
   artifacts:

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,6 @@ publish_win:
 	@echo "     UPLOAD -> BINTRAY, $(WINZIP)"
 	@curl -f -T ./build/distributions/$(WINZIP) -ubpicode:$(BINTRAY_API_KEY) -H "X-GPG-PASSPHRASE:$(BINTRAY_SIGN_GPG_PASSPHRASE)" "https://api.bintray.com/content/bpicode/fritzctl_win/fritzctl/$(FRITZCTL_VERSION)/$(WINZIP);publish=1"
 
-
 demogif:
 	@echo ">> DEMO GIF"
 	@go build -o mock/standalone/standalone  mock/standalone/main.go
@@ -281,3 +280,8 @@ demogif:
 	@(cd mock/ && asciinema rec -c '/bin/sh' ../images/fritzctl_demo.json)
 	@kill `cat </tmp/TEST_SERVER.PID`
 	@docker run --rm -v $(PWD)/images:/data asciinema/asciicast2gif -t monokai fritzctl_demo.json fritzctl_demo.gif
+
+release_github: pkg_all dist_all
+	@echo ">> GITHUB RELEASE"
+	@$(eval ASSETS:=$(shell find build/ -maxdepth 2 -type f -printf '-a %p\n'))
+	@hub release create --draft v$(FRITZCTL_VERSION) --message "fritzctl $(FRITZCTL_VERSION)" $(ASSETS)


### PR DESCRIPTION
Makes use of https://github.com/github/hub. Gitlab runner "deploy" (=release) job runs upon pushing of tags. Releases are created as draft.