### PR TITLE
config: ensure config.New() closes "file" again

### DIFF
--- a/config/fritzclientconfig.go
+++ b/config/fritzclientconfig.go
@@ -44,6 +44,7 @@ func New(path string) (*Config, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot open configuration file '%s'", path)
 	}
+	defer file.Close()
 	conf := Config{}
 	net := Net{}
 	pki := Pki{}


### PR DESCRIPTION
This commit ensures that when config.New() opens the config file
it is closed when the parsing is finished.