### PR TITLE
config: simplify code that reads yaml config

### DIFF
--- a/config/fritzclientconfig.go
+++ b/config/fritzclientconfig.go
@@ -44,6 +44,7 @@ func New(path string) (*Config, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot open configuration file '%s'", path)
 	}
+	defer file.Close()
 	conf := Config{}
 	net := Net{}
 	pki := Pki{}

--- a/config/fritzclientconfig.go
+++ b/config/fritzclientconfig.go
@@ -45,19 +45,9 @@ func New(path string) (*Config, error) {
 		return nil, errors.Wrapf(err, "cannot open configuration file '%s'", path)
 	}
 	defer file.Close()
+
 	conf := Config{}
-	net := Net{}
-	pki := Pki{}
-	login := Login{}
-	err = yaml.NewDecoder(file).Decode(&struct {
-		*Net
-		*Login
-		*Pki
-	}{&net, &login, &pki})
-	conf.Pki = &pki
-	conf.Login = &login
-	conf.Net = &net
-	if err != nil {
+	if err := yaml.NewDecoder(file).Decode(&conf); err != nil {
 		return nil, errors.Wrapf(err, "unable to parse configuration file '%s'", path)
 	}
 	return &conf, nil


### PR DESCRIPTION
This commit simplifies the reading of the user config yaml by
letting go-yaml handle the reading/assigning of the Config
struct.

Not sure why it's done the way it is done, maybe there is a good
reason. If so, please just close this PR :)

Based on #228 