### PR TITLE
fix login with username and password for FB 7490 and OS 7.21

### DIFF
--- a/config/fritzclientconfig.go
+++ b/config/fritzclientconfig.go
@@ -67,8 +67,3 @@ func New(path string) (*Config, error) {
 func (config *Config) GetLoginURL() string {
 	return fmt.Sprintf("%s://%s:%s%s", config.Net.Protocol, config.Net.Host, config.Net.Port, config.Login.LoginURL)
 }
-
-// GetLoginResponseURL returns the URL that is queried for the login challenge
-func (config *Config) GetLoginResponseURL(response string) string {
-	return fmt.Sprintf("%s?response=%s&username=%s", config.GetLoginURL(), response, config.Login.Username)
-}

--- a/fritz/fritzclient.go
+++ b/fritz/fritzclient.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/bpicode/fritzctl/config"
 	"github.com/bpicode/fritzctl/httpread"
@@ -97,9 +98,8 @@ func (client *Client) solveChallenge() (*SessionInfo, error) {
 func (client *Client) solveAttempt() func() (*http.Response, error) {
 	challengeAndPassword := client.SessionInfo.Challenge + "-" + client.Config.Login.Password
 	challengeResponse := client.SessionInfo.Challenge + "-" + toUTF16andMD5(challengeAndPassword)
-	url := client.Config.GetLoginResponseURL(challengeResponse)
 	return func() (*http.Response, error) {
-		return client.HTTPClient.Get(url)
+		return client.HTTPClient.PostForm(client.Config.GetLoginURL(), url.Values{"username": {client.Config.Login.Username}, "response": {challengeResponse}})
 	}
 }
 


### PR DESCRIPTION
I'm using a FritzBox 7490 with OS version 7.21 and couldn't get fritzctl to work when using login with username and password (password-only worked fine).

Apparently it is required to use a POST request with the parameters in the body when using username and password, I got it figured out by looking at the source of fb_tools (https://www.mengelke.de/Projekte/FritzBox-Tools).

I don't know if this is a bug in FritzOS and if this change will break anything else.
